### PR TITLE
Brighter color for editor.wordHighlightBackground

### DIFF
--- a/ayu-dark-lighter.json
+++ b/ayu-dark-lighter.json
@@ -34,7 +34,7 @@
 		"editor.selectionBackground": "#3a4553",
 		"editor.selectionHighlightBackground": "#121922",
 		"editor.selectionHighlightBorder": "#c8c8c8",
-		"editor.wordHighlightBackground": "#121922",
+		"editor.wordHighlightBackground": "#28303a",
 		"editor.wordHighlightStrongBackground": "#e6b45033",
 		"editorBracketMatch.background": "#3d424d4d",
 		"editorBracketMatch.border": "#3d424d99",


### PR DESCRIPTION
HI! I changed slightly the background color for the word highlight. It was set to a very dark one, almost not visible, and in some instances can be confusing.
